### PR TITLE
Fix min temp for mesh bulbs to be 1800

### DIFF
--- a/wyze_sdk/api/devices/bulbs.py
+++ b/wyze_sdk/api/devices/bulbs.py
@@ -145,10 +145,11 @@ class BulbsClient(BaseClient):
 
         :raises WyzeRequestError: if the new color temperature is not valid
         """
-        prop_def = BulbProps.color_temp()
-        prop_def.validate(color_temp)
 
         if device_model in DeviceModels.MESH_BULB:
+            prop_def = BulbProps.color_temp_mesh()
+            prop_def.validate(color_temp)
+
             return super()._api_client().run_action_list(
                 actions={
                     "key": "set_mesh_property",
@@ -157,6 +158,10 @@ class BulbsClient(BaseClient):
                     "provider_key": device_model,
                 }
             )
+
+        prop_def = BulbProps.color_temp()
+        prop_def.validate(color_temp)
+
         return super()._api_client().set_device_property(
             mac=device_mac, model=device_model, pid=prop_def.pid, value=color_temp)
 

--- a/wyze_sdk/models/__init__.py
+++ b/wyze_sdk/models/__init__.py
@@ -230,4 +230,4 @@ class PropDef(object):
             logging.debug(f"value {value} found in acceptable_values, passing")
             return
 
-        raise WyzeRequestError(f"{value} must be one of {self.acceptable_values}")
+        raise WyzeRequestError(f"{value} must be one of {self._acceptable_values}")

--- a/wyze_sdk/models/devices/bulbs.py
+++ b/wyze_sdk/models/devices/bulbs.py
@@ -29,7 +29,7 @@ class BulbProps(object):
 
     @classmethod
     def color_temp(cls) -> PropDef:
-        return PropDef("P1502", int, acceptable_values=range(2700, 6500 + 1))
+        return PropDef("P1502", int, acceptable_values=range(1800, 6500 + 1))
 
     @classmethod
     def color(cls) -> PropDef:

--- a/wyze_sdk/models/devices/bulbs.py
+++ b/wyze_sdk/models/devices/bulbs.py
@@ -29,6 +29,10 @@ class BulbProps(object):
 
     @classmethod
     def color_temp(cls) -> PropDef:
+        return PropDef("P1502", int, acceptable_values=range(2700, 6500 + 1))
+
+    @classmethod
+    def color_temp_mesh(cls) -> PropDef:
         return PropDef("P1502", int, acceptable_values=range(1800, 6500 + 1))
 
     @classmethod


### PR DESCRIPTION
Also, fixed bug in error raised when setting an out of bounds temp.

I'm not sure if this is the best way to go about setting two different temp ranges for two different bulbs, but it does seem to work. Note that I don't have any non-mesh bulbs to test it on, however.