### PR TITLE
Add Restart function to camera

### DIFF
--- a/wyze_sdk/api/devices/cameras.py
+++ b/wyze_sdk/api/devices/cameras.py
@@ -74,3 +74,13 @@ class CamerasClient(BaseClient):
         """
         return super()._api_client().run_action(
             mac=device_mac, provider_key=device_model, action_key="power_off")
+
+    def restart(self, *, device_mac: str, device_model: str, **kwargs) -> WyzeResponse:
+        """Restarts a camera.
+
+        Args:
+            :param str device_mac: The device mac. e.g. 'ABCDEF1234567890'
+            :param str device_model: The device model. e.g. 'WYZEC1-JZ'
+        """
+        return super()._api_client().run_action(
+            mac=device_mac, provider_key=device_model, action_key="restart")


### PR DESCRIPTION
Added procedure in cameras.py file to use "Restart" function built into Wyze app. Tested and working on Wyze Cam V2 but cannot speak for other models.