### PR TITLE
Add control_light and color_mode to bulb info

### DIFF
--- a/wyze_sdk/api/devices/bulbs.py
+++ b/wyze_sdk/api/devices/bulbs.py
@@ -231,7 +231,7 @@ class BulbsClient(BaseClient):
         )
 
     def _set_away_mode_disbled(self, *, device_mac: str, device_model: str, **kwargs) -> WyzeResponse:
-        prop_def = BulbProps.away_mode
+        prop_def = BulbProps.away_mode()
 
         if device_model in DeviceModels.MESH_BULB:
             return super()._api_client().run_action_list(

--- a/wyze_sdk/models/devices/base.py
+++ b/wyze_sdk/models/devices/base.py
@@ -39,7 +39,7 @@ class DeviceModels(object):
     OUTDOOR_PLUG = ['WLPPO-SUB']
     MESH_BULB = ['WLPA19C']
     PLUG = ['WLPP1', 'WLPP1CFH'] + OUTDOOR_PLUG
-    BULB = ['WLPA19'] + MESH_BULB
+    BULB = ['WLPA19', 'HL_HWB2'] + MESH_BULB
 
 
 class Product(object):


### PR DESCRIPTION
resolves: #41

`control_light` seems to be vestigial and I couldn't find anywhere that it was being utilized aside from being defined in `BulbProps`. Additionally, the `PropDef` seems to have been expecting that the value would boolean (`0` or `1` from the api) but on color bulbs (`MeshBulb`s) it seems that the value will be either `1` indicating that it's in 'color' mode or `2` indicating that it's in temperature mode. This commit adds the `control_light` property to the info output for all bulbs and further adds a computed `color_mode` property to mesh bulbs that indicates if the bulb is in `color` mode or `temperature` mode.

I have found this useful for caching a bulb's state in a reproducable way in order to do things like run color/brightness change sequences and then return the bulb to the original state - this was not possible without knowing if the bulb was originally utilizing the value from `color` or the `color_temp`.

Apologies if my code is not idiomatic, this is my first foray into python, happy to make changes if necessary.

I also have not tested with a non-color bulb but I assume that the value for white bulbs will still fall within the range `0-2`.