### PR TITLE
Clarify TOTP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ client = Client(email=os.environ['WYZE_EMAIL'], password=os.environ['WYZE_PASSWO
 
 ##### Multi-Factor Authentication (2FA) Support
 
-If your Wyze account has multi-factor authentication (2FA) enabled, you may be prompted for your 2FA code when authenticating via either supported method described above. If you wish to automate the MFA interaction, both the `Client` constructor and the `login()` method accept `totp_key` as input. If the TOTP key is provided, the MFA prompt should not appear.
+If your Wyze account has multi-factor authentication (2FA) enabled, you may be prompted for your 2FA code when authenticating via either supported method described above. If you wish to automate the MFA interaction, both the `Client` constructor and the `login()` method accept `totp_key` as input. If the TOTP key is provided, the MFA prompt should not appear. Your TOTP key can be obtained during the Wyze 2FA setup process and is the same code that you would typically input into an authenticator app during 2FA setup.
 
 ```python
 import os


### PR DESCRIPTION
Clarifies what a TOTP key is and where it is obtained.

This adds a sentence to the README to add some clarification explaining what a TOTP key is. It's easy to assume that TOTP key = TOTP code if you're not super familiar with the terminology differences. If a TOTP key isn't passed into the constructor and 2FA is enabled, it prompts the user for TOTP code input which got me further confused.

This is somewhat related to #105 and I think either this change or a similar doc change would make the package more user-friendly. 

Great package! Super useful. 🔥