### PR TITLE
137-add-camera-outdoor-v2 Add Support for the Outdoor Camera V2

### DIFF
--- a/wyze_sdk/models/devices/base.py
+++ b/wyze_sdk/models/devices/base.py
@@ -26,6 +26,7 @@ class DeviceModels(object):
     CAMERA_V2 = ['WYZEC1-JZ']
     CAMERA_V3 = ['WYZE_CAKP2JFUS']
     CAMERA_OUTDOOR = ['WVOD1']
+    CAMERA_OUTDOOR_V2 = ['HL_WCO2']
 
     LOCK = ['YD.LO1']
     LOCK_GATEWAY = ['YD.GW1']
@@ -34,7 +35,7 @@ class DeviceModels(object):
     CONTACT_SENSOR = ['DWS3U', 'DWS2U']
     MOTION_SENSOR = ['PIR3U', 'PIR2U']
     VACUUM = ['JA_RO2']
-    CAMERA = CAMERA_V1 + CAMERA_V2 + CAMERA_V3 + CAMERA_OUTDOOR
+    CAMERA = CAMERA_V1 + CAMERA_V2 + CAMERA_V3 + CAMERA_OUTDOOR + CAMERA_OUTDOOR_V2
     SCALE_ = ['JA.SC', 'JA.SC2']
     SCALE_S = ['WL_SC2']
     SCALE_X = ['WL_SC22135']  # placeholder


### PR DESCRIPTION
Add support for the "Outdoor V2" camera, model "'HL_WCO2"

This fixes issue #137 