### PR TITLE
Replace usage of distutils with separate strtobool

### DIFF
--- a/wyze_sdk/models/__init__.py
+++ b/wyze_sdk/models/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import distutils.util
 import logging
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, time
@@ -10,6 +9,19 @@ from functools import wraps
 from typing import Any, Callable, Iterable, Optional, Sequence, Set, Union
 
 from wyze_sdk.errors import WyzeObjectFormationError, WyzeRequestError, WyzeFeatureNotSupportedError
+
+def strtobool(v):
+    """    Convert a string representation of truth to true (1) or false (0).
+
+    True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0. Raises ValueError if val is anything else.
+    """
+    if isinstance(v, str):
+        v = v.lower()
+        if v in ('y', 'yes', 't', 'true', 'on', '1'):
+            return True
+        elif v in ('n', 'no', 'f', 'false', 'off', '0'):
+            return False
+    raise ValueError("Invalid truth value: {!r}".format(v))
 
 
 def datetime_to_epoch(datetime: datetime, ms: bool = True) -> int:
@@ -233,7 +245,7 @@ class PropDef(object):
     def validate(self, value: Any):
         if not isinstance(value, self._type):
             try:
-                value = bool(distutils.util.strtobool(str(value))) if self._type == bool else self._type(value)
+                value = bool(strtobool(str(value))) if self._type == bool else self._type(value)
             except TypeError:
                 logging.debug(f"could not cast value {value} into expected type {self._type}")
                 raise WyzeRequestError(f"{value} must be of type {self._type}")

--- a/wyze_sdk/models/devices/base.py
+++ b/wyze_sdk/models/devices/base.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import distutils.util
 import json
 import logging
 from abc import ABCMeta
 from datetime import datetime
 from typing import Any, Optional, Sequence, Set, Union
 
-from wyze_sdk.models import JsonObject, PropDef, epoch_to_datetime
+from wyze_sdk.models import JsonObject, PropDef, epoch_to_datetime, strtobool
 
 # -------------------------------------------------
 # Base Classes
@@ -142,7 +141,7 @@ class DeviceProp(object):
             else:
                 try:
                     if self._definition.type == bool:
-                        value = bool(distutils.util.strtobool(str(value)))
+                        value = bool(strtobool(str(value)))
                     elif self._definition.type == dict:
                         value = json.loads(value)
                     else:

--- a/wyze_sdk/models/devices/sensors.py
+++ b/wyze_sdk/models/devices/sensors.py
@@ -65,7 +65,7 @@ class SensorProps(object):
 
     @classmethod
     def open_close_state(cls) -> PropDef:
-        return PropDef("P1301", bool, int, [0, 1])
+        return PropDef("open_close_state", bool, int, [0, 1])
 
     @classmethod
     def motion_state(cls) -> PropDef:


### PR DESCRIPTION
Fixes https://github.com/shauntarves/wyze-sdk/issues/190 by defining a replacement `strtobool` to remove reliance on `distutils`, which is deprecated.

The implementation matches the reference for the original method at https://docs.python.org/2/distutils/apiref.html