### PR TITLE
Add the Scale Ultra

### DIFF
--- a/wyze_sdk/models/devices/base.py
+++ b/wyze_sdk/models/devices/base.py
@@ -38,7 +38,8 @@ class DeviceModels(object):
     SCALE_ = ['JA.SC', 'JA.SC2']
     SCALE_S = ['WL_SC2']
     SCALE_X = ['WL_SC3']
-    SCALE = SCALE_ + SCALE_S + SCALE_X
+    SCALE_ULTRA = ['WL_SCU']
+    SCALE = SCALE_ + SCALE_S + SCALE_X + SCALE_ULTRA
     WATCH = ['RA.WP1', 'RY.WA1']
     BAND = ['RY.HP1']
 


### PR DESCRIPTION
Based on a little testing script, this appears to be all that's needed to support the Scale Ultra. Before adding it, the device was not recognized and records could not be fetched. Afterwards, those things work.